### PR TITLE
feature(RefCell): Wraps the underlying TcpStream for the connection

### DIFF
--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -2,6 +2,7 @@
 extern crate byteorder;
 extern crate protobuf;
 extern crate rustc_serialize;
+extern crate scram;
 
 pub mod api;
 mod client;

--- a/src/lib/query.rs
+++ b/src/lib/query.rs
@@ -1,4 +1,5 @@
 use ql2::{Query, Query_QueryType, Term};
+use protobuf::ProtobufEnum;
 use rustc_serialize::json::{Json, ToJson};
 use std::collections::BTreeMap;
 
@@ -12,10 +13,8 @@ impl ToJson for Query {
     fn to_json(&self) -> Json {
         let mut obj = BTreeMap::new();
 
-        let field_type = match self.field_type {
-            Some(field_type) => field_type.to_json(),
-            None => Query_QueryType::START.to_json(),
-        }
-        obj.insert("type".to_owned(), field_type);
+        obj.insert("type".to_owned(), self.get_field_type().to_json());
+
+        Json::Object(obj)
     }
 }


### PR DESCRIPTION
This wraps the TCP stream used by the connection in a RefCell, to allow
for multiple mutations of the stream over the course of the handshake.
